### PR TITLE
New Return Value to Distinguish "Non-update" from Successful Update

### DIFF
--- a/NTPClient.cpp
+++ b/NTPClient.cpp
@@ -60,7 +60,7 @@ void NTPClient::begin(int port) {
   this->_udpSetup = true;
 }
 
-bool NTPClient::forceUpdate() {
+uint8_t NTPClient::forceUpdate() {
   #ifdef DEBUG_NTPClient
     Serial.println("Update from NTP Server");
   #endif
@@ -73,7 +73,7 @@ bool NTPClient::forceUpdate() {
   do {
     delay ( 10 );
     cb = this->_udp->parsePacket();
-    if (timeout > 100) return false; // timeout after 1000 ms
+    if (timeout > 100) return 0; // timeout after 1000 ms; return 0 if update fails
     timeout++;
   } while (cb == 0);
 
@@ -89,16 +89,16 @@ bool NTPClient::forceUpdate() {
 
   this->_currentEpoc = secsSince1900 - SEVENZYYEARS;
 
-  return true;  // return true after successful update
+  return 2;  // return 2 if update occurs successfully
 }
 
-bool NTPClient::update() {
+uint8_t NTPClient::update() {
   if ((millis() - this->_lastUpdate >= this->_updateInterval)     // Update after _updateInterval
     || this->_lastUpdate == 0) {                                // Update if there was no update yet.
     if (!this->_udpSetup) this->begin();                         // setup the UDP client if needed
     return this->forceUpdate();
   }
-  return false;   // return false if update does not occur
+  return 1;   // return 1 if update does not occur
 }
 
 unsigned long NTPClient::getEpochTime() const {

--- a/NTPClient.cpp
+++ b/NTPClient.cpp
@@ -89,7 +89,7 @@ bool NTPClient::forceUpdate() {
 
   this->_currentEpoc = secsSince1900 - SEVENZYYEARS;
 
-  return true;
+  return true;  // return true after successful update
 }
 
 bool NTPClient::update() {
@@ -98,7 +98,7 @@ bool NTPClient::update() {
     if (!this->_udpSetup) this->begin();                         // setup the UDP client if needed
     return this->forceUpdate();
   }
-  return true;
+  return false;   // return false if update does not occur
 }
 
 unsigned long NTPClient::getEpochTime() const {


### PR DESCRIPTION
Currently, `update()` returns _false_ only when an update fails during the call to `forceUpdate()`. This behavior is potentially useful for debugging. However, two other things can happen during `update()`: a successful update and a "non-update" (when `update()` does not call `forceUpdate()` because the `_updateInterval` requirement has not been met). However, no distinction exists between a successful update and a non-update—both situations return _true_. Users have expressed interest in knowing whether are not a successful update has actually occurred (see Issue #55).

That being the case, I propose revising `update()` and `forceUpdate()` to return an 8-bit unsigned integer value rather than a boolean so that a failed update returns 0, a “non-update” returns 1, and a successful update returns 2. It maintains the current boolean behavior to avoid breaking other people’s implementations of the library yet also returns distinct values for both successful updates and non-updates.