### PR TITLE
Increases the accuracy of the synchronization by a factor of 50. 

### DIFF
--- a/NTPClient.cpp
+++ b/NTPClient.cpp
@@ -114,6 +114,12 @@ bool NTPClient::forceUpdate() {
 
   this->_currentEpoc = secsSince1900 - SEVENZYYEARS;
 
+  // get also the most significant 16 bits of the fraction of the second
+  unsigned long fracWord = word(this->_packetBuffer[44], this->_packetBuffer[45]);
+  
+  // Account for fraction of the second.
+  this->_lastUpdate -=  (fracWord/66); // should be devided by 2^16/1000 = 65.536 but 66 is close enough
+  
   return true;  // return true after successful update
 }
 


### PR DESCRIPTION
Until now the fraction of the second was not taken into account. Therefore the resulting time offset is up to 1000 ms. Using the provided Information increases the accuracy of the synchronization to 20-30 milliseconds. And it requires just two lines of code.

![plot](https://user-images.githubusercontent.com/632873/110000953-27792200-7d14-11eb-9914-b766ec1f8a19.png)
In this plot both methods are compared. Plotted is the time difference in respect to a PPS signal provided by a GPS receiver.  For comparison the time was synchronized over 1000 times and the resulting time difference filled into the respective histogram.