### PR TITLE
Avoid blocking in NTPClient::update()

### DIFF
--- a/NTPClient.h
+++ b/NTPClient.h
@@ -10,8 +10,8 @@
 
 class NTPClient {
   private:
+
     UDP*          _udp;
-    bool          _udpSetup       = false;
 
     const char*   _poolServerName = "pool.ntp.org"; // Default time server
     IPAddress     _poolServerIP;
@@ -22,6 +22,14 @@ class NTPClient {
 
     unsigned long _currentEpoc    = 0;      // In s
     unsigned long _lastUpdate     = 0;      // In ms
+    unsigned long _lastRequest    = 0;      // In ms
+
+    enum class State {
+        uninitialized,
+        idle,
+        send_request,
+        wait_response,
+    } _state = State::uninitialized;
 
     byte          _packetBuffer[NTP_PACKET_SIZE];
 


### PR DESCRIPTION
When a NTP request is sent, it may take several milliseconds to retrieve the response.  This commit changes the NTPClient::update() behaviour to asynchronous allowing a NTP request to be sent with one update() call and handle the response when it's available in another call, eliminating active waiting.

This commit also changes the NTPClient::forceUpdate() implementation to rely on the logic in NTPClient::update().  However, the behaviour of this function does not change from the API user's perspective.  It is still synchronous, it only returns when all processing is complete.

This fixes issue #112.

Note that this is equivalent to what was suggested in PR https://github.com/arduino-libraries/NTPClient/pull/90.  I decided to reimplement it, because the other PR seems to be forgotten by the author and he still hasn't signed the CLA.