### PR TITLE
Allow setting timeOffset as long (fixes #72 #168)

### DIFF
--- a/NTPClient.cpp
+++ b/NTPClient.cpp
@@ -169,7 +169,7 @@ void NTPClient::end() {
   this->_udpSetup = false;
 }
 
-void NTPClient::setTimeOffset(int timeOffset) {
+void NTPClient::setTimeOffset(long timeOffset) {
   this->_timeOffset     = timeOffset;
 }
 

--- a/NTPClient.h
+++ b/NTPClient.h
@@ -89,7 +89,7 @@ class NTPClient {
     /**
      * Changes the time offset. Useful for changing timezones dynamically
      */
-    void setTimeOffset(int timeOffset);
+    void setTimeOffset(long timeOffset);
 
     /**
      * Set the update interval to another frequency. E.g. useful when the


### PR DESCRIPTION
timeOffset itself was already a long, but setTimeOffset only accepted integers. This should allow it to be set as long, so more timezones can be used.