### PR TITLE
Some useful methods to change NTP server dynamically.

### DIFF
--- a/NTPClient.cpp
+++ b/NTPClient.cpp
@@ -173,12 +173,33 @@ void NTPClient::setTimeOffset(int timeOffset) {
   this->_timeOffset     = timeOffset;
 }
 
+long NTPClient::getTimeOffset() {
+  return this->_timeOffset;
+}
+
 void NTPClient::setUpdateInterval(unsigned long updateInterval) {
   this->_updateInterval = updateInterval;
 }
 
+unsigned long NTPClient::getUpdateInterval() {
+  return this->_updateInterval;
+}
+
 void NTPClient::setPoolServerName(const char* poolServerName) {
     this->_poolServerName = poolServerName;
+}
+
+const char *NTPClient::getPoolServerName() {
+    return this->_poolServerName;
+}
+
+void NTPClient::setPoolServerIP(IPAddress poolServerIP) {
+  this->_poolServerIP = poolServerIP;
+  this->_poolServerName = NULL;
+}
+
+IPAddress NTPClient::getPoolServerIP() {
+    return this->_poolServerIP;
 }
 
 void NTPClient::sendNTPPacket() {

--- a/NTPClient.cpp
+++ b/NTPClient.cpp
@@ -231,3 +231,7 @@ void NTPClient::setRandomPort(unsigned int minValue, unsigned int maxValue) {
   randomSeed(analogRead(0));
   this->_port = random(minValue, maxValue);
 }
+
+void NTPClient::setLastUpdate(unsigned long sec) {
+  this->_lastUpdate = sec;
+}

--- a/NTPClient.h
+++ b/NTPClient.h
@@ -138,4 +138,9 @@ class NTPClient {
      * Stops the underlying UDP client
      */
     void end();
+
+    /**
+     * Set the last update time
+     */
+    void setLastUpdate(unsigned long sec);
 };

--- a/NTPClient.h
+++ b/NTPClient.h
@@ -44,6 +44,23 @@ class NTPClient {
      */
     void setPoolServerName(const char* poolServerName);
 
+    /**
+     * Get time server name
+     */
+    const char *getPoolServerName();
+
+    /**
+     * Set time server IP
+     *
+     * @param poolServerIP
+     */
+    void setPoolServerIP(IPAddress poolServerIP);
+
+    /*
+     * Get time server IP
+     */
+    IPAddress getPoolServerIP();
+
      /**
      * Set random local port
      */
@@ -92,10 +109,20 @@ class NTPClient {
     void setTimeOffset(int timeOffset);
 
     /**
+     * Get the time offset
+     */
+    long getTimeOffset();
+
+    /**
      * Set the update interval to another frequency. E.g. useful when the
      * timeOffset should not be set in the constructor
      */
     void setUpdateInterval(unsigned long updateInterval);
+
+    /**
+     * Get the update interval
+     */
+    unsigned long getUpdateInterval();
 
     /**
      * @return time formatted like `hh:mm:ss`


### PR DESCRIPTION
Allows you to set the IP address of the NTP server after initialization of the instance. And also reset the time of the last synchronization to force a time request.