### PR TITLE
Add function 'setPoolServerIP' like 'setPoolServerName'

### DIFF
--- a/NTPClient.cpp
+++ b/NTPClient.cpp
@@ -181,6 +181,11 @@ void NTPClient::setPoolServerName(const char* poolServerName) {
     this->_poolServerName = poolServerName;
 }
 
+void NTPClient::setPoolServerIP(IPAddress poolServerIP) {
+    this->_poolServerIP = poolServerIP;
+    this->_poolServerName = NULL;
+}
+
 void NTPClient::sendNTPPacket() {
   // set all bytes in the buffer to 0
   memset(this->_packetBuffer, 0, NTP_PACKET_SIZE);

--- a/NTPClient.h
+++ b/NTPClient.h
@@ -44,6 +44,11 @@ class NTPClient {
      */
     void setPoolServerName(const char* poolServerName);
 
+    /**
+     * Set time server IP address
+     */
+    void setPoolServerIP(IPAddress poolServerIP);
+
      /**
      * Set random local port
      */


### PR DESCRIPTION
As the title suggests, adds 'setPoolServerIP' that allows to change the server pool IP address after instantiation akin to how it's possible to change the server DNS name

---

Resolves https://github.com/arduino-libraries/NTPClient/issues/103