### PR TITLE
Introduce async NTP methods

### DIFF
--- a/NTPClient.cpp
+++ b/NTPClient.cpp
@@ -81,7 +81,7 @@ void NTPClient::begin(unsigned int port) {
   this->_udpSetup = true;
 }
 
-bool NTPClient::forceUpdate() {
+void NTPClient::startUpdate() {
   #ifdef DEBUG_NTPClient
     Serial.println("Update from NTP Server");
   #endif
@@ -91,19 +91,15 @@ bool NTPClient::forceUpdate() {
     this->_udp->flush();
 
   this->sendNTPPacket();
+}
 
-  // Wait till data is there or timeout...
-  byte timeout = 0;
-  int cb = 0;
-  do {
-    delay ( 10 );
-    cb = this->_udp->parsePacket();
-    if (timeout > 100) return false; // timeout after 1000 ms
-    timeout++;
-  } while (cb == 0);
+bool NTPClient::finishUpdate() {
+  #ifdef DEBUG_NTPClient
+    Serial.println("Check response from NTP Server");
+  #endif
 
-  this->_lastUpdate = millis() - (10 * (timeout + 1)); // Account for delay in reading the time
-
+  if(!this->_udp->parsePacket()) return false;
+  this->_lastUpdate = millis();
   this->_udp->read(this->_packetBuffer, NTP_PACKET_SIZE);
 
   unsigned long highWord = word(this->_packetBuffer[40], this->_packetBuffer[41]);
@@ -114,6 +110,24 @@ bool NTPClient::forceUpdate() {
 
   this->_currentEpoc = secsSince1900 - SEVENZYYEARS;
 
+  return true;  // return true after successful update
+
+}
+
+bool NTPClient::forceUpdate() {
+  this->startUpdate();
+
+  // Wait till data is there or timeout...
+  byte timeout = 0;
+  bool cb = false;
+  do {
+    delay ( 10 );
+    cb = this->finishUpdate();
+    if (timeout > 100) return false; // timeout after 1000 ms
+    timeout++;
+  } while (!cb);
+
+  this->_lastUpdate -= (10 * (timeout + 1)); // Account for delay in reading the time
   return true;  // return true after successful update
 }
 

--- a/NTPClient.h
+++ b/NTPClient.h
@@ -68,6 +68,18 @@ class NTPClient {
     bool update();
 
     /**
+     * This will send the initial packet to NTP Server.
+     */
+    void startUpdate();
+
+    /**
+     * This will check the response from NTP Server after the initial packet was sent.
+     *
+     * @return true if packet is received and time is updated, false if no packet received yet
+     */
+    bool finishUpdate();
+
+    /**
      * This will force the update from the NTP Server.
      *
      * @return true on success, false on failure

--- a/README.md
+++ b/README.md
@@ -50,3 +50,8 @@ void loop() {
 
 ## Function documentation
 `getEpochTime` returns the Unix epoch, which are the seconds elapsed since 00:00:00 UTC on 1 January 1970 (leap seconds are ignored, every day is treated as having 86400 seconds). **Attention**: If you have set a time offset this time offset will be added to your epoch timestamp.
+
+To work asynchronously, use `startUpdate` and `finishUpdate` methods instead of `forceUpdate` (or `update`).
+First, call `startUpdate` after network connection is established; then, keep calling `finishUpdate` time to time, unless it returns `true` (that same moment `isTimeSet` starts returning `true` too).
+This way you may perform any work while waiting for a response from the time server.
+**Note**: `startUpdate` may still block for several seconds performing DNS query; to avoid this, first resolve the NTP server's IP address, and then use it instead of its DNS name.

--- a/examples/Async/Async.ino
+++ b/examples/Async/Async.ino
@@ -1,0 +1,40 @@
+#include <NTPClient.h>
+// change next line to use with another board/shield
+#include <ESP8266WiFi.h>
+//#include <WiFi.h> // for WiFi shield
+//#include <WiFi101.h> // for WiFi 101 shield or MKR1000
+#include <WiFiUdp.h>
+
+const char *ssid     = "<SSID>";
+const char *password = "<PASSWORD>";
+
+WiFiUDP ntpUDP;
+
+// You can specify the time server pool and the offset (in seconds, can be
+// changed later with setTimeOffset() ). Additionally you can specify the
+// update interval (in milliseconds, can be changed using setUpdateInterval() ).
+NTPClient timeClient(ntpUDP, "europe.pool.ntp.org", 3600, 60000);
+
+void setup(){
+  Serial.begin(115200);
+
+  WiFi.begin(ssid, password);
+
+  while ( WiFi.status() != WL_CONNECTED ) {
+    delay ( 500 );
+    Serial.println("WiFi is not connected yet...");
+  }
+
+  timeClient.startUpdate();
+}
+
+void loop() {
+  if(timeClient.isTimeSet()) {
+    Serial.println(timeClient.getFormattedTime());
+  }
+  else {
+    Serial.println("Time is not updated yet...");
+    timeClient.finishUpdate();
+  }
+  delay(1000);
+}

--- a/keywords.txt
+++ b/keywords.txt
@@ -22,3 +22,5 @@ getEpochTime	KEYWORD2
 setTimeOffset	KEYWORD2
 setUpdateInterval	KEYWORD2
 setPoolServerName	KEYWORD2
+startUpdate	KEYWORD2
+finishUpdate	KEYWORD2


### PR DESCRIPTION
Waiting for a response to NTP query might be a time-consuming operation, so it is not perfect that `forceUpdate()` blocks in this case.

I've implemented `startUpdate()` and `finishUpdate()` methods that may be useful to process a response once it is received, not block while waiting for it.

An example is added too to show how to use these methods, `Async.ino`.